### PR TITLE
Issue #2919376 - Restore some kind of field-level dependencies to mappings that don't delete mappings when fields are deleted

### DIFF
--- a/modules/salesforce_mapping/src/Entity/SalesforceMapping.php
+++ b/modules/salesforce_mapping/src/Entity/SalesforceMapping.php
@@ -6,7 +6,6 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Plugin\DefaultLazyPluginCollection;
-use Drupal\Core\Plugin\DefaultSingleLazyPluginCollection;
 use Drupal\salesforce\Exception;
 use Drupal\salesforce\SelectQuery;
 use Drupal\salesforce_mapping\MappingConstants;
@@ -385,7 +384,6 @@ class SalesforceMapping extends ConfigEntityBase implements SalesforceMappingInt
     }
     return $changed;
   }
-
 
   /**
    * {@inheritdoc}

--- a/modules/salesforce_mapping/src/Entity/SalesforceMappingInterface.php
+++ b/modules/salesforce_mapping/src/Entity/SalesforceMappingInterface.php
@@ -4,11 +4,12 @@ namespace Drupal\salesforce_mapping\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityWithPluginCollectionInterface;
 
 /**
  * Mapping between Drupal and Salesforce records.
  */
-interface SalesforceMappingInterface extends ConfigEntityInterface {
+interface SalesforceMappingInterface extends ConfigEntityInterface, EntityWithPluginCollectionInterface {
 
   /**
    * Magic getter method for mapping properties.

--- a/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/Properties.php
+++ b/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/Properties.php
@@ -4,6 +4,7 @@ namespace Drupal\salesforce_mapping\Plugin\SalesforceMappingField;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\salesforce_mapping\SalesforceMappingFieldPluginBase;
 use Drupal\salesforce_mapping\Entity\SalesforceMappingInterface;
 
@@ -101,6 +102,26 @@ class Properties extends SalesforceMappingFieldPluginBase {
     }
     asort($options);
     return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginDefinition() {
+    $definition = parent::getPluginDefinition();
+    if ($field = FieldConfig::loadByName($this->mapping->getDrupalEntityType(), $this->mapping->getDrupalBundle(), $this->config('drupal_field_value'))) {
+      $definition['config_dependencies']['config'][] = $field->getConfigDependencyName();
+    }
+    return $definition;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function checkFieldMappingDependency(array $dependencies) {
+    if ($field = FieldConfig::loadByName($this->mapping->getDrupalEntityType(), $this->mapping->getDrupalBundle(), $this->config('drupal_field_value'))) {
+      return !empty($dependencies['config'][$field->getConfigDependencyName()]);
+    }
   }
 
 }

--- a/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/PropertiesExtended.php
+++ b/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/PropertiesExtended.php
@@ -105,7 +105,10 @@ class PropertiesExtended extends SalesforceMappingFieldPluginBase {
    */
   public function getPluginDefinition() {
     $definition = parent::getPluginDefinition();
-    list($field_name, $referenced_field_name) = explode('.', $this->config('drupal_field_value'), 2);
+    $field_name = $this->config('drupal_field_value');
+    if (strpos($field_name, '.')) {
+      list($field_name, $dummy) = explode('.', $field_name, 2);
+    }
     // Add reference field.
     if ($field = FieldConfig::loadByName($this->mapping->getDrupalEntityType(), $this->mapping->getDrupalBundle(), $field_name)) {
       $definition['config_dependencies']['config'][] = $field->getConfigDependencyName();

--- a/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/RelatedIDs.php
+++ b/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/RelatedIDs.php
@@ -5,6 +5,7 @@ namespace Drupal\salesforce_mapping\Plugin\SalesforceMappingField;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 
+use Drupal\field\Entity\FieldConfig;
 use Drupal\salesforce\SFID;
 use Drupal\salesforce\SObject;
 use Drupal\salesforce_mapping\Entity\SalesforceMappingInterface;
@@ -132,6 +133,41 @@ class RelatedIDs extends SalesforceMappingFieldPluginBase {
     }
     asort($options);
     return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginDefinition() {
+    $definition = parent::getPluginDefinition();
+    // Add reference field.
+    if ($field = FieldConfig::loadByName($this->mapping->getDrupalEntityType(), $this->mapping->getDrupalBundle(), $this->config('drupal_field_value'))) {
+      $definition['config_dependencies']['config'][] = $field->getConfigDependencyName();
+      // Add dependencies of referenced field.
+      foreach ($field->getDependencies() as $type => $dependency) {
+        foreach ($dependency as $item) {
+          $definition['config_dependencies'][$type][] = $item;
+        }
+      }
+    }
+    return $definition;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function checkFieldMappingDependency(array $dependencies) {
+    $definition = $this->getPluginDefinition();
+    foreach ($definition['config_dependencies'] as $type => $dependency) {
+      foreach ($dependency as $item) {
+        if (!empty($dependencies[$type][$item])) {
+          return TRUE;
+        }
+      }
+    }
   }
 
 }

--- a/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/RelatedIDs.php
+++ b/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/RelatedIDs.php
@@ -138,9 +138,6 @@ class RelatedIDs extends SalesforceMappingFieldPluginBase {
   /**
    * {@inheritdoc}
    */
-  /**
-   * {@inheritdoc}
-   */
   public function getPluginDefinition() {
     $definition = parent::getPluginDefinition();
     // Add reference field.

--- a/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/RelatedProperties.php
+++ b/modules/salesforce_mapping/src/Plugin/SalesforceMappingField/RelatedProperties.php
@@ -97,7 +97,10 @@ class RelatedProperties extends SalesforceMappingFieldPluginBase {
    */
   public function getPluginDefinition() {
     $definition = parent::getPluginDefinition();
-    list($field_name, $referenced_field_name) = explode(':', $this->config('drupal_field_value'), 2);
+    $field_name = $this->config('drupal_field_value');
+    if (strpos($field_name, ':')) {
+      list($field_name, $dummy) = explode(':', $field_name, 2);
+    }
     // Add reference field.
     if ($field = FieldConfig::loadByName($this->mapping->getDrupalEntityType(), $this->mapping->getDrupalBundle(), $field_name)) {
       $definition['config_dependencies']['config'][] = $field->getConfigDependencyName();

--- a/modules/salesforce_mapping/src/SalesforceMappingFieldPluginBase.php
+++ b/modules/salesforce_mapping/src/SalesforceMappingFieldPluginBase.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\salesforce_mapping;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -11,11 +10,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityReferenceSelection\SelectionInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
-use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\TypedData\DataDefinitionInterface;
-use Drupal\field\Entity\FieldConfig;
 use Drupal\salesforce\Event\SalesforceEvents;
 use Drupal\salesforce\Event\SalesforceWarningEvent;
 use Drupal\salesforce\Exception as SalesforceException;

--- a/modules/salesforce_mapping/src/SalesforceMappingFieldPluginBase.php
+++ b/modules/salesforce_mapping/src/SalesforceMappingFieldPluginBase.php
@@ -15,6 +15,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\TypedData\DataDefinitionInterface;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\salesforce\Event\SalesforceEvents;
 use Drupal\salesforce\Event\SalesforceWarningEvent;
 use Drupal\salesforce\Exception as SalesforceException;
@@ -34,7 +35,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * @see \Drupal\salesforce_mapping\SalesforceMappingFieldPluginInterface
  * @see \Drupal\Core\Plugin\PluginFormInterface
  */
-abstract class SalesforceMappingFieldPluginBase extends PluginBase implements SalesforceMappingFieldPluginInterface, PluginFormInterface, ConfigurablePluginInterface, ContainerFactoryPluginInterface {
+abstract class SalesforceMappingFieldPluginBase extends PluginBase implements SalesforceMappingFieldPluginInterface {
 
   /**
    * The label of the mapping.
@@ -100,6 +101,13 @@ abstract class SalesforceMappingFieldPluginBase extends PluginBase implements Sa
   protected $eventDispatcher;
 
   /**
+   * The mapping to which this instance is attached.
+   *
+   * @var \Drupal\salesforce_mapping\Entity\SalesforceMappingInterface
+   */
+  protected $mapping;
+
+  /**
    * SalesforceMappingFieldPluginBase constructor.
    *
    * @param array $configuration
@@ -126,6 +134,9 @@ abstract class SalesforceMappingFieldPluginBase extends PluginBase implements Sa
    */
   public function __construct(array $configuration, $plugin_id, array $plugin_definition, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityFieldManagerInterface $entity_field_manager, RestClientInterface $rest_client, EntityTypeManagerInterface $etm, DateFormatterInterface $dateFormatter, EventDispatcherInterface $event_dispatcher) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
+    if (!empty($configuration['mapping'])) {
+      $this->mapping = $configuration['mapping'];
+    }
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->entityFieldManager = $entity_field_manager;
     $this->salesforceClient = $rest_client;
@@ -518,8 +529,9 @@ abstract class SalesforceMappingFieldPluginBase extends PluginBase implements Sa
   /**
    * {@inheritdoc}
    */
-  public function getDependencies(SalesforceMappingInterface $mapping) {
-    return [];
+  public function checkFieldMappingDependency(array $dependencies) {
+    // No config dependencies by default.
+    return FALSE;
   }
 
   /**

--- a/modules/salesforce_mapping/src/SalesforceMappingFieldPluginInterface.php
+++ b/modules/salesforce_mapping/src/SalesforceMappingFieldPluginInterface.php
@@ -2,14 +2,18 @@
 
 namespace Drupal\salesforce_mapping;
 
+use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\DependentPluginInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\salesforce\SObject;
 use Drupal\salesforce_mapping\Entity\SalesforceMappingInterface;
 
 /**
  * Defines an interface for salesforce mapping plugins.
  */
-interface SalesforceMappingFieldPluginInterface {
+interface SalesforceMappingFieldPluginInterface extends PluginFormInterface, ConfigurablePluginInterface, ContainerFactoryPluginInterface {
 
   /**
    * Returns label of the mapping field plugin.
@@ -139,15 +143,13 @@ interface SalesforceMappingFieldPluginInterface {
   public function pull();
 
   /**
-   * Return an array of dependencies.
+   * On dependency removal, determine if this plugin needs to be removed.
    *
-   * Compatible with DependentPluginInterface::calculateDependencies().
+   * @param array $dependencies
+   *   Dependencies, as provided to ConfigEntityInterface::onDependencyRemoval.
    *
-   * @return array
-   *   Depdencies.
-   *
-   * @see \Drupal\Component\Plugin\DependentPluginInterface::calculateDependencies
+   * @return bool
+   *   TRUE if the field should be removed, otherwise false.
    */
-  public function getDependencies(SalesforceMappingInterface $mapping);
-
+  public function checkFieldMappingDependency(array $dependencies);
 }

--- a/modules/salesforce_mapping/src/SalesforceMappingFieldPluginInterface.php
+++ b/modules/salesforce_mapping/src/SalesforceMappingFieldPluginInterface.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\salesforce_mapping;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
 use Drupal\Component\Plugin\DependentPluginInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -13,7 +13,7 @@ use Drupal\salesforce_mapping\Entity\SalesforceMappingInterface;
 /**
  * Defines an interface for salesforce mapping plugins.
  */
-interface SalesforceMappingFieldPluginInterface extends PluginFormInterface, ConfigurablePluginInterface, ContainerFactoryPluginInterface {
+interface SalesforceMappingFieldPluginInterface extends PluginFormInterface, DependentPluginInterface, ConfigurableInterface, ContainerFactoryPluginInterface {
 
   /**
    * Returns label of the mapping field plugin.
@@ -152,4 +152,5 @@ interface SalesforceMappingFieldPluginInterface extends PluginFormInterface, Con
    *   TRUE if the field should be removed, otherwise false.
    */
   public function checkFieldMappingDependency(array $dependencies);
+
 }

--- a/modules/salesforce_mapping_ui/src/Form/SalesforceMappingFieldsForm.php
+++ b/modules/salesforce_mapping_ui/src/Form/SalesforceMappingFieldsForm.php
@@ -209,7 +209,7 @@ class SalesforceMappingFieldsForm extends SalesforceMappingFormBase {
     }
 
     $row['config'] = $field_plugin->buildConfigurationForm($form, $form_state);
-    $row['config']['id'] = ['#type' => 'value', 'value' => $i];
+    $row['config']['id'] = ['#type' => 'value', '#value' => $i];
     // @TODO implement "lock/unlock" logic here:
     // @TODO convert these to AJAX operations
     $operations = [

--- a/modules/salesforce_webform/src/Plugin/SalesforceMappingField/WebformElements.php
+++ b/modules/salesforce_webform/src/Plugin/SalesforceMappingField/WebformElements.php
@@ -85,6 +85,35 @@ class WebformElements extends SalesforceMappingFieldPluginBase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function getPluginDefinition() {
+    $definition = parent::getPluginDefinition();
+    $element_parts = explode('__', $this->config('drupal_field_value'));
+    $main_element_name = reset($element_parts);
+    $webform = $this->entityTypeManager->getStorage('webform')->load($this->mapping->get('drupal_bundle'));
+    $definition['config_dependencies']['config'][] = $webform->getConfigDependencyName();
+    $webform_element = $webform->getElement($main_element_name);
+    // Unfortunately, the best we can do for webform dependencies is a single
+    // dependency on the top-level webform, which is itself a monolithic config.
+    // @TODO implement webform-element-changed hook, if that exists.
+    $definition['config_dependencies']['config'][] = $webform->getConfigDependencyName();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function checkFieldMappingDependency(array $dependencies) {
+    $definition = $this->getPluginDefinition();
+    foreach ($definition['config_dependencies']['config'] as $dependency) {
+      if (!empty($dependencies['config'][$dependency])) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
    * Form options helper.
    */
   protected function getConfigurationOptions($mapping) {


### PR DESCRIPTION
via http://drupal.org/node/2919376

Adds dependency framework to Salesforce Mapping + field mapping plugins.

Expected behavior is:
- Upon deleting a mapped field, remove the field from the mapping
- Upon deleting a mapped entity, delete the mapping